### PR TITLE
chore: ignore local tooling dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,7 @@ todo.txt
 
 # vercel
 .vercel
+
+# local tooling
+.claude/
+.playwright-mcp/


### PR DESCRIPTION
## Summary
- Add `.claude/` and `.playwright-mcp/` to `.gitignore` so local Claude Code and Playwright MCP artifacts stop appearing in `git status`.

## Test plan
- [x] \`git status\` clean after adding those directories locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)