### PR TITLE
feat: add react-native-menu/menu PR to OSS contributions

### DIFF
--- a/src/lib/contributions.ts
+++ b/src/lib/contributions.ts
@@ -26,4 +26,10 @@ export const contributions: Contribution[] = [
     description: "Add workspace tabs — nested tab layer within each workspace",
     state: "open",
   },
+  {
+    repo: "react-native-menu/menu",
+    url: "https://github.com/react-native-menu/menu/pull/1197",
+    description: "Fix Android build on Expo SDK 55 / RN 0.83 / Kotlin 2.x",
+    state: "open",
+  },
 ];


### PR DESCRIPTION
## Summary
- Add the open `react-native-menu/menu` PR (#1197) to the OSS Contributions section
- PR fixes Android build compatibility with Expo SDK 55 / RN 0.83 / Kotlin 2.x

## Test plan
- [x] Lint passes
- [x] Build passes
- [x] Contribution appears in the OSS Contributions section with open PR icon

🤖 Generated with [Claude Code](https://claude.com/claude-code)